### PR TITLE
ignora java modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-version}</version>
                 <configuration>
-                    <argLine>${argLine} -XX:MaxPermSize=256m</argLine>
+<!--                    <argLine>${argLine} -XX:MaxPermSize=256m</argLine>-->
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
"Solución" rápida al problema _inaccesibleObject_ ignorando los modulos de Java. Ver [SO](https://stackoverflow.com/questions/50334742/how-to-get-junit5-with-jdk10-jigsaw-and-maven3-to-work)